### PR TITLE
fix: Update system package names for Ubuntu

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1,2 +1,3 @@
 ffmpeg
-libsndfile
+libsndfile1
+libsndfile1-dev


### PR DESCRIPTION
Change libsndfile to libsndfile1 and add libsndfile1-dev for Streamlit Cloud compatibility